### PR TITLE
Rename concept type label to "Research Area"

### DIFF
--- a/transform/concept_indexer.go
+++ b/transform/concept_indexer.go
@@ -11,7 +11,7 @@ type ConceptIndexer struct {
 
 // Index adds fields from the resource to the Solr Document
 func (m *ConceptIndexer) Index(resource *models.Concept, doc solr.Document) solr.Document {
-	doc.Set("type_ssi", "Concept")
+	doc.Set("type_ssi", "Research Area")
 	doc.Set("title_tesi", resource.Label)
 	return doc
 }

--- a/transform/publication_serializer_test.go
+++ b/transform/publication_serializer_test.go
@@ -16,7 +16,7 @@ func TestSerializePublicationResource(t *testing.T) {
 		CreatedYear: 2018,
 		Concepts: []*models.Concept{&models.Concept{
 			URI:   "http://example.com/concept1",
-			Label: "Concept 1"}},
+			Label: "Research Area 1"}},
 	}
 
 	doc := indexer.Serialize(resource)


### PR DESCRIPTION
Fixes #164

Note that we will not see a difference in the webapp until we rebuild the index