### PR TITLE
Make assigned optional for grants

### DIFF
--- a/models/grant.go
+++ b/models/grant.go
@@ -27,7 +27,10 @@ func NewGrant(data map[string]rdf.Term) *Grant {
 	}
 
 	obj.PI = &Labeled{data["pi"].String(), data["pi_label"].String()}
-	obj.Assigned = &Labeled{data["assigned"].String(), data["assigned_label"].String()}
+
+	if data["assigned"] != nil {
+		obj.Assigned = &Labeled{data["assigned"].String(), data["assigned_label"].String()}
+	}
 
 	if start := data["start"]; start != nil {
 		obj.Start = start.String()

--- a/repository/sparql_reader.go
+++ b/repository/sparql_reader.go
@@ -270,8 +270,10 @@ func (r *SparqlReader) queryGrants(f func(*sparql.Results) error, ids ...string)
 				?pi_role a <http://vivoweb.org/ontology/core#PrincipalInvestigatorRole> .
 				?pi_role <http://purl.obolibrary.org/obo/RO_0000052> ?pi .
 				?pi <http://www.w3.org/2004/02/skos/core#prefLabel> ?pi_label .
-				?id <http://vivoweb.org/ontology/core#assignedBy> ?assigned .
-				?assigned <http://www.w3.org/2004/02/skos/core#prefLabel> ?assigned_label .
+				OPTIONAL {
+				  ?id <http://vivoweb.org/ontology/core#assignedBy> ?assigned .
+					?assigned <http://www.w3.org/2004/02/skos/core#prefLabel> ?assigned_label .
+				}
 				OPTIONAL {
 					?id <http://purl.org/cerif/frapo/hasStartDate> ?start .
 				}


### PR DESCRIPTION
Fixes #171 

If the grant data is missing the "assigned" information, we still want to index it.